### PR TITLE
Add improved info popups

### DIFF
--- a/src/frontend/components/AccessoryLinks.tsx
+++ b/src/frontend/components/AccessoryLinks.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import Link from "next/link";
 
 interface NavbarLinksProps {
@@ -8,14 +9,30 @@ const NavbarLinks = ({ extraClasses }: NavbarLinksProps): JSX.Element => {
   const commonClasses = "px-1 xs:px-4 sm:px-2 xl:mx-4 hover:scale-105";
   return (
     <div
-      className={
-        "absolute top-0 right-0 h-10 xs:h-14 mt-2 text-lg text-center font-Barlow flex items-center " +
-        "sm:h-20 sm:mt-0 sm:text-sm " +
-        "md:h-24 md:text-base " +
-        "lg:h-28 lg:text-lg lg:right-2 " +
-        "xl:text-xl xl:right-2 " +
+      className={clsx(
+        "absolute",
+        "top-0",
+        "right-0",
+        "h-10",
+        "xs:h-14",
+        "mt-2",
+        "text-lg",
+        "text-center",
+        "font-Barlow",
+        "flex",
+        "items-center",
+        "sm:h-20",
+        "sm:mt-0",
+        "sm:text-sm",
+        "md:h-24",
+        "md:text-base",
+        "lg:h-28",
+        "lg:text-lg",
+        "lg:right-2",
+        "xl:text-xl",
+        "xl:right-2",
         extraClasses
-      }
+      )}
     >
       <Link href="/about">
         <a href="" className={commonClasses}>

--- a/src/frontend/components/DisplayContainer/CardPreviewGrid.tsx
+++ b/src/frontend/components/DisplayContainer/CardPreviewGrid.tsx
@@ -1,9 +1,12 @@
+import clsx from "clsx";
+import { useContext } from "react";
+import { InfoPopupContext } from "../../../pages/_app";
 import { ProfessorPreview } from "../../../types";
 import InfoPopup from "../InfoPopup";
 
 interface CardPreviewGridProps {
   preview: ProfessorPreview;
-  showInfo: boolean;
+  isLast: boolean;
   ratioState: { displayARatio: boolean; toggleARatio(): void };
   numGradeState: {
     collapseNumGrades: boolean;
@@ -20,16 +23,16 @@ const CardPreviewGrid = ({
     displayRating,
     toggleDisplayRating: toggleDisplayNumGrades,
   },
-  showInfo,
+  isLast,
 }: CardPreviewGridProps): JSX.Element => {
+  const { isShowing } = useContext(InfoPopupContext);
+  const showInfo = isShowing && isLast;
+
   function colorScore(value: number): string {
     if (value < 33.33) return " font-bold text-red-600 ";
     if (value < 66.66) return " font-bold text-yellow-400 ";
     return " font-bold text-green-500 ";
   }
-
-  const popupPositionClasses =
-    "absolute top-8 sm:top-8 md:top-10 lg:top-[2.625rem] xl:top-11";
   const hoverAndActiveClasses = "hover:bg-gray-50 ";
 
   const aRatioCol: [JSX.Element, JSX.Element] = [
@@ -62,7 +65,16 @@ const CardPreviewGrid = ({
     >
       {displayARatio ? aRatio : passingRatio}%
       {showInfo && !collapseNumGrades && (
-        <div className={popupPositionClasses}>
+        <div
+          className={clsx(
+            "absolute",
+            "top-8",
+            "sm:top-8",
+            "md:top-10",
+            "lg:top-[2.625rem]",
+            "xl:top-11"
+          )}
+        >
           <InfoPopup extraClasses="w-28 sm:w-36 text-center " isUpsideDown>
             Click to see the ratio for passing grades
           </InfoPopup>{" "}
@@ -125,13 +137,31 @@ const CardPreviewGrid = ({
     </h2>,
     <h1
       key={"ratingValue"}
-      className={
-        "m-0 p-0 flex justify-center items-center " +
-        "text-sm md:text-base xl:text-lg " +
-        "border-r-2 border-gray-300 "
-      }
+      className={clsx(
+        "relative",
+        "m-0",
+        "p-0",
+        "flex",
+        "justify-center",
+        "items-center",
+        "text-sm",
+        "md:text-base",
+        "xl:text-lg",
+        "border-r-2",
+        "border-gray-300"
+      )}
     >
       {ratingColVal}
+      {showInfo && collapseNumGrades && (
+        <div className={clsx("absolute", "top-8")}>
+          <InfoPopup
+            extraClasses={clsx("w-28", "sm:w-36", "text-center")}
+            isUpsideDown
+          >
+            Click to see the total number of grades given
+          </InfoPopup>{" "}
+        </div>
+      )}
     </h1>,
   ];
 
@@ -162,11 +192,13 @@ const CardPreviewGrid = ({
   if (collapseNumGrades) columns.splice(1, 1);
   return (
     <div
-      className={
-        `w-7/12 grid ${collapseNumGrades ? "grid-cols-3" : "grid-cols-4"}  ` +
-        "xs:w-6/12 " +
+      className={clsx(
+        "w-7/12",
+        "grid",
+        collapseNumGrades ? "grid-cols-3" : "grid-cols-4",
+        "xs:w-6/12",
         "sm:w-5/12"
-      }
+      )}
     >
       {columns.map((title) => title[0])}
       {columns.map((value) => value[1])}

--- a/src/frontend/components/DisplayContainer/ProfessorCard.tsx
+++ b/src/frontend/components/DisplayContainer/ProfessorCard.tsx
@@ -108,7 +108,7 @@ const ResultsProfessorCard = ({
       )}
       <CardPreviewGrid
         ratioState={ratioState}
-        showInfo={showInfo}
+        isLast={showInfo}
         numGradeState={numGradeState}
         preview={profPreview}
       ></CardPreviewGrid>

--- a/src/frontend/components/InfoPopup.tsx
+++ b/src/frontend/components/InfoPopup.tsx
@@ -1,4 +1,6 @@
-import { useState } from "react";
+import clsx from "clsx";
+import { useContext, useState } from "react";
+import { InfoPopupContext } from "../../pages/_app";
 
 interface InfoPopupProps {
   extraClasses?: string;
@@ -11,26 +13,52 @@ const InfoPopup = ({
   children,
   isUpsideDown,
 }: InfoPopupProps): JSX.Element => {
-  const [isShowing, setIsShowing] = useState<boolean>(true);
+  const { isShowing, hide } = useContext(InfoPopupContext);
   return (
     <div
-      className={
-        `${
-          isShowing ? "" : "hidden"
-        } static z-40 h-fit overflow-visible flex flex-col items-center ` +
+      className={clsx(
+        isShowing ? "" : "hidden",
+        "static",
+        "z-40",
+        "h-fit",
+        "overflow-visible",
+        "flex",
+        "flex-col",
+        "items-center",
         extraClasses
-      }
+      )}
     >
       <div
-        className={
-          "static z-20 w-full p-4 bg-white border-2 border-brandAmber text-brandAmber rounded-lg " +
-          "font-bold text-sm sm:text-base antialiased md:p-5 "
-        }
+        className={clsx(
+          "static",
+          "z-20",
+          "w-full",
+          "p-3.5",
+          "md:p-3",
+          "bg-white",
+          "border-2",
+          "border-brandAmber",
+          "text-brandAmber",
+          "rounded-lg",
+          "font-bold",
+          "text-sm",
+          "sm:text-base",
+          "antialiased"
+        )}
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
-          onClick={() => setIsShowing(false)}
-          className="absolute cursor-pointer top-1 right-1 h-5 w-5 text-brandAmber hover:scale-125 "
+          onClick={() => hide()}
+          className={clsx(
+            "absolute",
+            "cursor-pointer",
+            "top-1",
+            "right-1",
+            "h-5",
+            "w-5",
+            "text-brandAmber",
+            "hover:scale-125"
+          )}
           viewBox="0 0 20 20"
           fill="currentColor"
         >
@@ -43,9 +71,15 @@ const InfoPopup = ({
         {children}
       </div>
       <div
-        className={`absolute ${
-          isUpsideDown ? "-top-2" : "-bottom-2"
-        } h-5 w-5 rotate-45 z-10 bg-brandAmber`}
+        className={clsx(
+          "absolute",
+          isUpsideDown ? "-top-2" : "-bottom-2",
+          "h-5",
+          "w-5",
+          "rotate-45",
+          "z-10",
+          "bg-brandAmber"
+        )}
       ></div>
     </div>
   );

--- a/src/frontend/components/ResultScrollView.tsx
+++ b/src/frontend/components/ResultScrollView.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 interface ResultScrollContainerProps {
   children: JSX.Element | Array<JSX.Element | string>;
 }
@@ -7,13 +8,30 @@ const ResultScrollView = ({
 }: ResultScrollContainerProps): JSX.Element => {
   return (
     <div
-      className={
-        "h-full w-11/12 mt-3 pt-3 px-3 mx-auto rounded-t-lg border-t-2 border-x-2 flex flex-col overflow-y-scroll " +
-        "sm:w-10/12 sm:pt-4 sm:px-4 " +
-        "md:w-9/12 md:pt-5 md:px-5 " +
-        "lg:w-7/12 lg:pt-6 lg:px-6 " +
-        "xl:w-6/12 "
-      }
+      className={clsx(
+        "h-full",
+        "w-11/12",
+        "mt-3",
+        "pt-3",
+        "px-3",
+        "mx-auto",
+        "rounded-t-lg",
+        "border-t-2",
+        "border-x-2",
+        "flex",
+        "flex-col",
+        "overflow-y-scroll",
+        "sm:w-10/12",
+        "sm:pt-4",
+        "sm:px-4",
+        "md:w-9/12",
+        "md:pt-5",
+        "md:px-5",
+        "lg:w-7/12",
+        "lg:pt-6",
+        "lg:px-6",
+        "xl:w-6/12"
+      )}
     >
       {children}
     </div>

--- a/src/frontend/components/SearchHome/SearchHome.tsx
+++ b/src/frontend/components/SearchHome/SearchHome.tsx
@@ -3,6 +3,7 @@ import SearchForm from "../SearchForm";
 import Logo from "../Logo";
 import { SearchType } from "../../../types";
 import { capitalize1stLetter } from "../../utils";
+import clsx from "clsx";
 
 const SearchHome = (): JSX.Element => {
   const [selectedOption, setSelectedOption] = useState<SearchType>("professor");
@@ -64,15 +65,28 @@ const SearchTypeTab = ({
 }: FormTypeTabsProps): JSX.Element => {
   return (
     <button
-      className={
-        `${
-          isSelected
-            ? "bg-brandAmber text-white text "
-            : "bg-white text-brandAmber opacity-75 "
-        }` +
-        "w-1/3 px-2 py-1 rounded-t-lg border-4 border-spacing-0 border-brandAmber text-center select-none " +
-        "font-Barlow font-bold text-sm sm:text-base md:text-lg lg:text-xl xl:text-2xl cursor-pointer"
-      }
+      className={clsx(
+        isSelected
+          ? "bg-brandAmber text-white text "
+          : "bg-white text-brandAmber opacity-75 ",
+        "w-1/3",
+        "px-2",
+        "py-1",
+        "rounded-t-lg",
+        "border-4",
+        "border-spacing-0",
+        "border-brandAmber",
+        "text-center",
+        "select-none",
+        "font-Barlow",
+        "font-bold",
+        "text-sm",
+        "sm:text-base",
+        "md:text-lg",
+        "lg:text-xl",
+        "xl:text-2xl",
+        "cursor-pointer"
+      )}
       onClick={() => updateSelectedOption(typeText)}
     >
       <p className={isSelected ? "" : "hover:scale-105"}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,15 +2,24 @@ import "../frontend/styles/global.css";
 import type { AppProps } from "next/app";
 import { Analytics } from "@vercel/analytics/react";
 import Head from "next/head";
+import { createContext, useState } from "react";
+export const InfoPopupContext = createContext({
+  isShowing: true,
+  hide: () => {},
+});
 
 function ProfesScore({ Component, pageProps }: AppProps) {
+  const [isShowing, setIsShowing] = useState(true);
+  const hide = () => setIsShowing(false);
   return (
     <>
       <Head>
         <link rel="shortcut icon" href="/favicon.ico" />
         <title>ProfesScore</title>
       </Head>
-      <Component {...pageProps} />
+      <InfoPopupContext.Provider value={{ isShowing, hide }}>
+        <Component {...pageProps} />
+      </InfoPopupContext.Provider>
       <Analytics />
     </>
   );


### PR DESCRIPTION
## Describe your changes
Added a new info popup for the collapsed version of the preview metrics grid component. It explains that you can click the rating column to see the total grades (when it is collapsed on mobile). Also made the info popup show state an app-wide context, so closing the popup once keeps it closed.

## Issue ticket number or describe the feature
features explained above

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I have commented my code in hard-to-understand areas
- [x] If it is a new feature, I have thoroughly tested it myself
