### PR TITLE
Added loading to the bottom of the results bar

### DIFF
--- a/src/frontend/components/DisplayContainer/DisplayContainer.tsx
+++ b/src/frontend/components/DisplayContainer/DisplayContainer.tsx
@@ -84,13 +84,6 @@ const DisplayContainer = ({
       </ResultScrollView>
     );
 
-  if (isLoading)
-    return (
-      <ResultScrollView>
-        <Message>Loading...</Message>
-      </ResultScrollView>
-    );
-
   if (searchResults?.length === 0) {
     return (
       <ResultScrollView>
@@ -137,6 +130,12 @@ const DisplayContainer = ({
                 idx === currentResults.length - 1 ? handleObserver : undefined
               }
             ></CourseGroup>
+          )}
+
+          {isLoading && (
+            <div className="pb-3">
+              <Message>Loading...</Message>
+            </div>
           )}
         </div>
       ))}

--- a/src/frontend/components/DisplayContainer/DisplayContainer.tsx
+++ b/src/frontend/components/DisplayContainer/DisplayContainer.tsx
@@ -131,7 +131,6 @@ const DisplayContainer = ({
               }
             ></CourseGroup>
           )}
-
           {isLoading && (
             <div className="pb-3">
               <Message>Loading...</Message>

--- a/src/frontend/components/DisplayContainer/DisplayContainer.tsx
+++ b/src/frontend/components/DisplayContainer/DisplayContainer.tsx
@@ -131,13 +131,13 @@ const DisplayContainer = ({
               }
             ></CourseGroup>
           )}
-          {isLoading && (
-            <div className="pb-3">
-              <Message>Loading...</Message>
-            </div>
-          )}
         </div>
       ))}
+      {isLoading && (
+        <div className="pb-3">
+          <Message>Loading...</Message>
+        </div>
+      )}
     </ResultScrollView>
   );
 };

--- a/src/frontend/components/ResultScrollView.tsx
+++ b/src/frontend/components/ResultScrollView.tsx
@@ -1,6 +1,6 @@
 import clsx from "clsx";
 interface ResultScrollContainerProps {
-  children: JSX.Element | Array<JSX.Element | string>;
+  children: React.ReactNode;
 }
 
 const ResultScrollView = ({


### PR DESCRIPTION
## Describe your changes
Added a loading indicator to the bottom of the results collection. 
![Screen Recording 2022-11-20 at 5 36 04 PM mov](https://user-images.githubusercontent.com/26678464/202942668-241a01c3-12f8-47d4-a4eb-5cda613d4ee0.gif)

## Issue ticket number or describe the feature

## Checklist before requesting a review
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] If it is a new feature, I have thoroughly tested it myself
